### PR TITLE
Activate prune-state cmd

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -154,12 +154,6 @@ func pruneState(ctx *cli.Context) error {
 
 	chaindb := utils.MakeChainDatabase(ctx, stack, false)
 
-	// Quorum
-	if config.Eth.Genesis.Config.IsQuorum {
-		log.Error("Can not prune state when using GoQuorum as this has an impact on private state")
-		return errors.New("prune-state is not available when IsQuorum is enabled")
-	}
-
 	pruner, err := pruner.NewPruner(chaindb, stack.ResolvePath(""), stack.ResolvePath(config.Eth.TrieCleanCacheJournal), ctx.GlobalUint64(utils.BloomFilterSizeFlag.Name))
 	if err != nil {
 		log.Error("Failed to open snapshot tree", "err", err)


### PR DESCRIPTION
`geth snapshot prune-state` is made unavailable in GoQuorum, but it is not necessary to disable it in the source code, just to prevent it from running when full-sync is used.
Therefore, I have modified the source code to enable `prune-state`.