### PR TITLE
ibet custom versioning

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -26,7 +26,7 @@ const (
 	VersionPatch = 3        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 
-	QuorumVersionMajor = 23
+	QuorumVersionMajor = 2
 	QuorumVersionMinor = 4
 	QuorumVersionPatch = 0
 )


### PR DESCRIPTION
We forked Quorum 23.4.0 and are currently maintaining it independently. 
Starting with this version, we would like to change the versioning of our client to our own versioning.