### PR TITLE
Revise geth version notation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   lint:
     name: 'Code linters'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: 'Setup Go ${{ env.GO_VERSION }}'
         uses: actions/setup-go@v5
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04"]
+        os: ["ubuntu-latest"]
     env:
       QUORUM_IGNORE_TEST_PACKAGES: github.com/ethereum/go-ethereum/les,github.com/ethereum/go-ethereum/les/flowcontrol,github.com/ethereum/go-ethereum/mobile
     runs-on: ${{ matrix.os }}

--- a/params/version.go
+++ b/params/version.go
@@ -21,13 +21,13 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 10       // Minor version component of the current release
-	VersionPatch = 3        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 0  // Major version component of the current release
+	VersionMinor = 0  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
+	VersionMeta  = "" // Version metadata to append to the version string
 
 	QuorumVersionMajor = 2
-	QuorumVersionMinor = 4
+	QuorumVersionMinor = 5
 	QuorumVersionPatch = 0
 )
 


### PR DESCRIPTION
close #113 

This fix changes the node names to the following:
```
name: "Geth/validator-1/v0.0.0-6f4cc130-20250306(quorum-v2.5.0)/linux-amd64/go1.23.7"
```