### PR TITLE
Refactor tests to use t.TempDir and cleanup go.mod deps

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - staticcheck
     - unconvert
     - unused
+    - usetesting
     - whitespace
 
     # - structcheck # lots of false positives

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -1795,14 +1795,9 @@ func TestGolangBindings(t *testing.T) {
 		t.Skip("go sdk not found for testing")
 	}
 	// Create a temporary workspace for the test suite
-	ws, err := os.MkdirTemp("", "binding-test")
-	if err != nil {
-		t.Fatalf("failed to create temporary workspace: %v", err)
-	}
-	//defer os.RemoveAll(ws)
-
+	ws := t.TempDir()
 	pkg := filepath.Join(ws, "bindtest")
-	if err = os.MkdirAll(pkg, 0700); err != nil {
+	if err := os.MkdirAll(pkg, 0700); err != nil {
 		t.Fatalf("failed to create package: %v", err)
 	}
 	// Generate the test suite for all the contracts

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -54,7 +54,6 @@ func TestWatchNewFile(t *testing.T) {
 	t.Parallel()
 
 	dir, ks := tmpKeyStore(t, false)
-	defer os.RemoveAll(dir)
 
 	// Ensure the watcher is started before adding any files.
 	ks.Accounts()
@@ -94,7 +93,7 @@ func TestWatchNoDir(t *testing.T) {
 	t.Parallel()
 
 	// Create ks but not the directory that it watches.
-	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
+	dir := filepath.Join(t.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
 
 	list := ks.Accounts()
@@ -105,7 +104,6 @@ func TestWatchNoDir(t *testing.T) {
 
 	// Create the directory and copy a key file into it.
 	os.MkdirAll(dir, 0700)
-	defer os.RemoveAll(dir)
 	file := filepath.Join(dir, "aaa")
 	if err := cp.CopyFile(file, cachetestAccounts[0].URL.Path); err != nil {
 		t.Fatal(err)
@@ -319,7 +317,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary kesytore to test with
-	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
+	dir := filepath.Join(t.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
 
 	list := ks.Accounts()
@@ -330,7 +328,6 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 	// Create the directory and copy a key file into it.
 	os.MkdirAll(dir, 0700)
-	defer os.RemoveAll(dir)
 	file := filepath.Join(dir, "aaa")
 
 	// Place one of our testfiles in there

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -37,7 +37,6 @@ var testSigData = make([]byte, 32)
 
 func TestKeyStore(t *testing.T) {
 	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
 
 	a, err := ks.NewAccount("foo")
 	if err != nil {
@@ -71,8 +70,7 @@ func TestKeyStore(t *testing.T) {
 }
 
 func TestSign(t *testing.T) {
-	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, true)
 
 	pass := "" // not used but required by API
 	a1, err := ks.NewAccount(pass)
@@ -88,8 +86,7 @@ func TestSign(t *testing.T) {
 }
 
 func TestSignWithPassphrase(t *testing.T) {
-	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, true)
 
 	pass := "passwd"
 	acc, err := ks.NewAccount(pass)
@@ -116,8 +113,7 @@ func TestSignWithPassphrase(t *testing.T) {
 }
 
 func TestTimedUnlock(t *testing.T) {
-	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, true)
 
 	pass := "foo"
 	a1, err := ks.NewAccount(pass)
@@ -151,8 +147,7 @@ func TestTimedUnlock(t *testing.T) {
 }
 
 func TestOverrideUnlock(t *testing.T) {
-	dir, ks := tmpKeyStore(t, false)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, false)
 
 	pass := "foo"
 	a1, err := ks.NewAccount(pass)
@@ -192,8 +187,7 @@ func TestOverrideUnlock(t *testing.T) {
 
 // This test should fail under -race if signing races the expiration goroutine.
 func TestSignRace(t *testing.T) {
-	dir, ks := tmpKeyStore(t, false)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, false)
 
 	// Create a test account.
 	a1, err := ks.NewAccount("")
@@ -221,8 +215,7 @@ func TestSignRace(t *testing.T) {
 // addition and removal of wallet event subscriptions.
 func TestWalletNotifierLifecycle(t *testing.T) {
 	// Create a temporary kesytore to test with
-	dir, ks := tmpKeyStore(t, false)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, false)
 
 	// Ensure that the notification updater is not running yet
 	time.Sleep(250 * time.Millisecond)
@@ -282,8 +275,7 @@ type walletEvent struct {
 // Tests that wallet notifications and correctly fired when accounts are added
 // or deleted from the keystore.
 func TestWalletNotifications(t *testing.T) {
-	dir, ks := tmpKeyStore(t, false)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, false)
 
 	// Subscribe to the wallet feed and collect events.
 	var (
@@ -344,8 +336,8 @@ func TestWalletNotifications(t *testing.T) {
 
 // TestImportExport tests the import functionality of a keystore.
 func TestImportECDSA(t *testing.T) {
-	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, true)
+
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatalf("failed to generate key: %v", key)
@@ -363,8 +355,8 @@ func TestImportECDSA(t *testing.T) {
 
 // TestImportECDSA tests the import and export functionality of a keystore.
 func TestImportExport(t *testing.T) {
-	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, true)
+
 	acc, err := ks.NewAccount("old")
 	if err != nil {
 		t.Fatalf("failed to create account: %v", acc)
@@ -373,8 +365,9 @@ func TestImportExport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to export account: %v", acc)
 	}
-	dir2, ks2 := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir2)
+
+	_, ks2 := tmpKeyStore(t, true)
+
 	if _, err = ks2.Import(json, "old", "old"); err == nil {
 		t.Errorf("importing with invalid password succeeded")
 	}
@@ -393,8 +386,8 @@ func TestImportExport(t *testing.T) {
 // TestImportRace tests the keystore on races.
 // This test should fail under -race if importing races.
 func TestImportRace(t *testing.T) {
-	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStore(t, true)
+
 	acc, err := ks.NewAccount("old")
 	if err != nil {
 		t.Fatalf("failed to create account: %v", acc)
@@ -403,8 +396,9 @@ func TestImportRace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to export account: %v", acc)
 	}
-	dir2, ks2 := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir2)
+
+	_, ks2 := tmpKeyStore(t, true)
+
 	var atom uint32
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -459,10 +453,7 @@ func checkEvents(t *testing.T, want []walletEvent, have []walletEvent) {
 }
 
 func tmpKeyStore(t *testing.T, encrypted bool) (string, *KeyStore) {
-	d, err := os.MkdirTemp("", "eth-keystore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 	newKs := NewPlaintextKeyStore
 	if encrypted {
 		newKs = func(kd string) *KeyStore { return NewKeyStore(kd, veryLightScryptN, veryLightScryptP) }

--- a/accounts/keystore/plain_test.go
+++ b/accounts/keystore/plain_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -31,10 +30,7 @@ import (
 )
 
 func tmpKeyStoreIface(t *testing.T, encrypted bool) (dir string, ks keyStore) {
-	d, err := os.MkdirTemp("", "geth-keystore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 	if encrypted {
 		ks = &keyStorePassphrase{d, veryLightScryptN, veryLightScryptP, true}
 	} else {
@@ -44,8 +40,7 @@ func tmpKeyStoreIface(t *testing.T, encrypted bool) (dir string, ks keyStore) {
 }
 
 func TestKeyStorePlain(t *testing.T) {
-	dir, ks := tmpKeyStoreIface(t, false)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStoreIface(t, false)
 
 	pass := "" // not used but required by API
 	k1, account, err := storeNewKey(ks, rand.Reader, pass)
@@ -65,8 +60,7 @@ func TestKeyStorePlain(t *testing.T) {
 }
 
 func TestKeyStorePassphrase(t *testing.T) {
-	dir, ks := tmpKeyStoreIface(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStoreIface(t, true)
 
 	pass := "foo"
 	k1, account, err := storeNewKey(ks, rand.Reader, pass)
@@ -86,8 +80,7 @@ func TestKeyStorePassphrase(t *testing.T) {
 }
 
 func TestKeyStorePassphraseDecryptionFail(t *testing.T) {
-	dir, ks := tmpKeyStoreIface(t, true)
-	defer os.RemoveAll(dir)
+	_, ks := tmpKeyStoreIface(t, true)
 
 	pass := "foo"
 	k1, account, err := storeNewKey(ks, rand.Reader, pass)
@@ -101,7 +94,6 @@ func TestKeyStorePassphraseDecryptionFail(t *testing.T) {
 
 func TestImportPreSaleKey(t *testing.T) {
 	dir, ks := tmpKeyStoreIface(t, true)
-	defer os.RemoveAll(dir)
 
 	// file content of a presale key file generated with:
 	// python pyethsaletool.py genwallet

--- a/cmd/ethkey/message_test.go
+++ b/cmd/ethkey/message_test.go
@@ -17,17 +17,12 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestMessageSignVerify(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "ethkey-test")
-	if err != nil {
-		t.Fatal("Can't create temporary directory:", err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	keyfile := filepath.Join(tmpdir, "the-keyfile")
 	message := "test message"

--- a/cmd/geth/accountcmd_plugin_test.go
+++ b/cmd/geth/accountcmd_plugin_test.go
@@ -176,10 +176,10 @@ func TestImportPluginAccount_ErrIfInvalidRawkey(t *testing.T) {
 }
 
 func TestImportPluginAccount_ErrIfCLIFlagsNotSet(t *testing.T) {
-	tmpfile, err := os.CreateTemp("", "rawkey")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "rawkey")
 	require.NoError(t, err)
 	t.Log("creating tmp file", "path", tmpfile.Name())
-	defer os.Remove(tmpfile.Name())
+
 	_, err = tmpfile.Write([]byte("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b"))
 	require.NoError(t, err)
 	err = tmpfile.Close()
@@ -214,10 +214,10 @@ func TestImportPluginAccount_ErrIfCLIFlagsNotSet(t *testing.T) {
 }
 
 func TestImportPluginAccount_ErrIfInvalidNewAccountConfig(t *testing.T) {
-	tmpfile, err := os.CreateTemp("", "rawkey")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "rawkey")
 	require.NoError(t, err)
 	t.Log("creating tmp file", "path", tmpfile.Name())
-	defer os.Remove(tmpfile.Name())
+
 	_, err = tmpfile.Write([]byte("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b"))
 	require.NoError(t, err)
 	err = tmpfile.Close()
@@ -260,10 +260,10 @@ func TestImportPluginAccount_ErrIfInvalidNewAccountConfig(t *testing.T) {
 }
 
 func TestImportPluginAccount_ErrIfUnsupportedPluginInConfig(t *testing.T) {
-	tmpfile, err := os.CreateTemp("", "rawkey")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "rawkey")
 	require.NoError(t, err)
 	t.Log("creating tmp file", "path", tmpfile.Name())
-	defer os.Remove(tmpfile.Name())
+
 	_, err = tmpfile.Write([]byte("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b"))
 	require.NoError(t, err)
 	err = tmpfile.Close()

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -90,7 +90,6 @@ func TestConsoleWelcome(t *testing.T) {
 	coinbase := "0x491937757d1b26e29c507b8d4c0b233c2747e68d"
 
 	datadir := setupIstanbul(t)
-	defer os.RemoveAll(datadir)
 
 	// Start a geth console, make sure it's cleaned up and terminate the console
 	geth := runMinimalGeth(t, "--datadir", datadir, "--miner.etherbase", coinbase, "console")
@@ -134,7 +133,7 @@ func TestAttachWelcome(t *testing.T) {
 	coinbase := "0x491937757d1b26e29c507b8d4c0b233c2747e68d"
 
 	datadir := setupIstanbul(t)
-	defer os.RemoveAll(datadir)
+
 	if runtime.GOOS == "windows" {
 		ipc = `\\.\pipe\geth` + strconv.Itoa(trulyRandInt(100000, 999999))
 	} else {

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -107,7 +107,6 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	defer SetResetPrivateConfig("ignore")()
 	// Create a temporary data directory to use and inspect later
 	datadir := tmpdir(t)
-	defer os.RemoveAll(datadir)
 
 	// Start a Geth instance with the requested flags set and immediately terminate
 	if genesis != "" {

--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -78,7 +78,6 @@ func TestCustomGenesis(t *testing.T) {
 	for i, tt := range customGenesisTests {
 		// Create a temporary data directory to use and inspect later
 		datadir := tmpdir(t)
-		defer os.RemoveAll(datadir)
 
 		// copy the node key and static-nodes.json so that geth can start with the raft consensus
 		gethDir := filepath.Join(datadir, "geth")
@@ -109,7 +108,6 @@ func TestCustomGenesisUpgradeWithPrivacyEnhancementsBlock(t *testing.T) {
 	defer SetResetPrivateConfig("ignore")()
 	// Create a temporary data directory to use and inspect later
 	datadir := tmpdir(t)
-	defer os.RemoveAll(datadir)
 
 	// copy the node key and static-nodes.json so that geth can start with the raft consensus
 	gethDir := filepath.Join(datadir, "geth")

--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func tmpdir(t *testing.T) string {
-	dir, err := os.MkdirTemp("", "geth-test")
+	dir, err := os.MkdirTemp("", "geth-test") // nolint:usetesting
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,15 +81,9 @@ func runGeth(t *testing.T, args ...string) *testgeth {
 		}
 	}
 	if tt.Datadir == "" {
+		// The temporary datadir will be removed automatically if something fails below.
 		tt.Datadir = tmpdir(t)
-		tt.Cleanup = func() { os.RemoveAll(tt.Datadir) }
 		args = append([]string{"--datadir", tt.Datadir}, args...)
-		// Remove the temporary datadir if something fails below.
-		defer func() {
-			if t.Failed() {
-				tt.Cleanup()
-			}
-		}()
 	}
 
 	// Boot "geth". This actually runs the test binary but the TestMain

--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -83,6 +83,7 @@ func runGeth(t *testing.T, args ...string) *testgeth {
 	if tt.Datadir == "" {
 		// The temporary datadir will be removed automatically if something fails below.
 		tt.Datadir = tmpdir(t)
+		tt.Cleanup = func() { os.RemoveAll(tt.Datadir) }
 		args = append([]string{"--datadir", tt.Datadir}, args...)
 	}
 

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -105,13 +105,8 @@ func TestSetImmutabilityThreshold(t *testing.T) {
 }
 
 func TestSetPlugins_whenTypical(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	arbitraryJSONFile := path.Join(tmpDir, "arbitary.json")
 	if err := os.WriteFile(arbitraryJSONFile, []byte("{}"), 0644); err != nil {
 		t.Fatal(err)

--- a/common/http/config_test.go
+++ b/common/http/config_test.go
@@ -116,7 +116,7 @@ func TestDefaultTimeoutsUsedWhenNoConfigFileSpecified(t *testing.T) {
 }
 
 func TestLoadSocketConfigWithTimeouts(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "socketConfigFileWithTimeouts.toml")
+	configFile := filepath.Join(t.TempDir(), "socketConfigFileWithTimeouts.toml")
 	if err := os.WriteFile(configFile, []byte(socketConfigFileWithTimeouts), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestLoadSocketConfigWithTimeouts(t *testing.T) {
 }
 
 func TestLoadSocketConfigWithDefaultTimeouts(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "socketConfigFileNoTimeouts.toml")
+	configFile := filepath.Join(t.TempDir(), "socketConfigFileNoTimeouts.toml")
 	if err := os.WriteFile(configFile, []byte(socketConfigFileNoTimeouts), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestLoadSocketConfigWithDefaultTimeouts(t *testing.T) {
 }
 
 func TestLoadHttpConfigWithTimeouts(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "httpConfigFileWithTimeouts.toml")
+	configFile := filepath.Join(t.TempDir(), "httpConfigFileWithTimeouts.toml")
 	if err := os.WriteFile(configFile, []byte(httpConfigFileWithTimeouts), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestLoadHttpConfigWithTimeouts(t *testing.T) {
 }
 
 func TestLoadHttpConfigWithInvalidTls(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "httpConfigFileWithInvalidTlsMode.toml")
+	configFile := filepath.Join(t.TempDir(), "httpConfigFileWithInvalidTlsMode.toml")
 	if err := os.WriteFile(configFile, []byte(httpConfigFileWithInvalidTlsMode), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestLoadHttpConfigWithInvalidTls(t *testing.T) {
 }
 
 func TestLoadHttpTlsConfigWithTimeouts(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "httpTlsConfigFileWithTimeouts.toml")
+	configFile := filepath.Join(t.TempDir(), "httpTlsConfigFileWithTimeouts.toml")
 	if err := os.WriteFile(configFile, []byte(httpTlsConfigFileWithTimeouts), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestLoadHttpTlsConfigWithTimeouts(t *testing.T) {
 }
 
 func TestLoadHttpConfigWithDefaultTimeouts(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "httpTlsConfigFileNoTimeouts.toml")
+	configFile := filepath.Join(t.TempDir(), "httpTlsConfigFileNoTimeouts.toml")
 	if err := os.WriteFile(configFile, []byte(httpTlsConfigFileNoTimeouts), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestLoadHttpConfigWithDefaultTimeouts(t *testing.T) {
 }
 
 func TestHTTPTlsWithBlankRootCert(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "httpTlsConfigFileNoRootCert.toml")
+	configFile := filepath.Join(t.TempDir(), "httpTlsConfigFileNoRootCert.toml")
 	if err := os.WriteFile(configFile, []byte(httpTlsConfigFileNoRootCert), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestHTTPTlsWithBlankRootCert(t *testing.T) {
 }
 
 func TestHTTPTlsMissingClientCerts(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "invalidHttpTlsConfigFileNoClientCert.toml")
+	configFile := filepath.Join(t.TempDir(), "invalidHttpTlsConfigFileNoClientCert.toml")
 	if err := os.WriteFile(configFile, []byte(invalidHttpTlsConfigFileNoClientCert), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestHTTPTlsMissingClientCerts(t *testing.T) {
 }
 
 func TestHTTPTlsMissingOnlyClientKey(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "invalidHttpTlsConfigFileOnlyClientCert.toml")
+	configFile := filepath.Join(t.TempDir(), "invalidHttpTlsConfigFileOnlyClientCert.toml")
 	if err := os.WriteFile(configFile, []byte(invalidHttpTlsConfigFileOnlyClientCert), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestHTTPTlsMissingOnlyClientKey(t *testing.T) {
 }
 
 func TestHTTPTlsMissingOnlyClientCert(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "invalidHttpTlsConfigFileOnlyClientKey.toml")
+	configFile := filepath.Join(t.TempDir(), "invalidHttpTlsConfigFileOnlyClientKey.toml")
 	if err := os.WriteFile(configFile, []byte(invalidHttpTlsConfigFileOnlyClientKey), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestHTTPTlsMissingOnlyClientCert(t *testing.T) {
 }
 
 func TestTlsWithHTTPUrlOnly(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "httpTlsConfigFileWithHTTPOnly.toml")
+	configFile := filepath.Join(t.TempDir(), "httpTlsConfigFileWithHTTPOnly.toml")
 	if err := os.WriteFile(configFile, []byte(httpTlsConfigFileWithHTTPOnly), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestTlsWithHTTPUrlOnly(t *testing.T) {
 }
 
 func TestSocketWithHTTPNotAllowed(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "invalidConfigWithSocketAndHttp.toml")
+	configFile := filepath.Join(t.TempDir(), "invalidConfigWithSocketAndHttp.toml")
 	if err := os.WriteFile(configFile, []byte(invalidConfigWithSocketAndHttp), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestSocketWithHTTPNotAllowed(t *testing.T) {
 }
 
 func TestEitherSocketOrHTTPMustBeSpecified(t *testing.T) {
-	configFile := filepath.Join(os.TempDir(), "invalidConfigWithNoSocketOrHttp.toml")
+	configFile := filepath.Join(t.TempDir(), "invalidConfigWithNoSocketOrHttp.toml")
 	if err := os.WriteFile(configFile, []byte(invalidConfigWithNoSocketOrHttp), 0600); err != nil {
 		t.Fatalf("Failed to create config file for unit test, error: %v", err)
 	}

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -86,10 +85,7 @@ type tester struct {
 // Please ensure you call Close() on the returned tester to avoid leaks.
 func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 	// Create a temporary storage for the node keys and initialize it
-	workspace, err := os.MkdirTemp("", "console-tester-")
-	if err != nil {
-		t.Fatalf("failed to create temporary keystore: %v", err)
-	}
+	workspace := t.TempDir()
 
 	// Create a networkless protocol stack and start an Ethereum service within
 	stack, err := node.New(&node.Config{DataDir: workspace, UseLightweightKDF: true, Name: testInstance})
@@ -150,7 +146,6 @@ func (env *tester) Close(t *testing.T) {
 	if err := env.stack.Close(); err != nil {
 		t.Errorf("failed to tear down embedded node: %v", err)
 	}
-	os.RemoveAll(env.workspace)
 }
 
 // Tests that the node lists the correct welcome message, notably that it contains

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -152,7 +152,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	if !disk {
 		db = rawdb.NewMemoryDatabase()
 	} else {
-		dir, err := os.MkdirTemp("", "eth-core-bench")
+		dir, err := os.MkdirTemp("", "eth-core-bench") // nolint:usetesting
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -251,7 +251,7 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 
 func benchWriteChain(b *testing.B, full bool, count uint64) {
 	for i := 0; i < b.N; i++ {
-		dir, err := os.MkdirTemp("", "eth-chain-bench")
+		dir, err := os.MkdirTemp("", "eth-chain-bench") // nolint:usetesting
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -266,7 +266,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 }
 
 func benchReadChain(b *testing.B, full bool, count uint64) {
-	dir, err := os.MkdirTemp("", "eth-chain-bench")
+	dir, err := os.MkdirTemp("", "eth-chain-bench") // nolint:usetesting
 	if err != nil {
 		b.Fatalf("cannot create temporary directory: %v", err)
 	}

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -22,7 +22,6 @@ package core
 
 import (
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -1755,11 +1754,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	// fmt.Println(tt.dump(true))
 
 	// Create a temporary persistent database
-	datadir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temporary datadir: %v", err)
-	}
-	os.RemoveAll(datadir)
+	datadir := t.TempDir()
 
 	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
 	if err != nil {

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -22,7 +22,6 @@ package core
 import (
 	"fmt"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1955,11 +1954,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	// fmt.Println(tt.dump(false))
 
 	// Create a temporary persistent database
-	datadir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temporary datadir: %v", err)
-	}
-	os.RemoveAll(datadir)
+	datadir := t.TempDir()
 
 	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
 	if err != nil {

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -22,7 +22,6 @@ package core
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -57,11 +56,7 @@ type snapshotTestBasic struct {
 
 func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Block) {
 	// Create a temporary persistent database
-	datadir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temporary datadir: %v", err)
-	}
-	os.RemoveAll(datadir)
+	datadir := t.TempDir()
 
 	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
 	if err != nil {
@@ -205,7 +200,6 @@ func (basic *snapshotTestBasic) dump() string {
 func (basic *snapshotTestBasic) teardown() {
 	basic.db.Close()
 	basic.gendb.Close()
-	os.RemoveAll(basic.datadir)
 }
 
 // snapshotTest is a test case type for normal snapshot recovery.

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -650,11 +650,8 @@ func TestFastVsFullChains(t *testing.T) {
 		t.Fatalf("failed to insert receipt %d: %v", n, err)
 	}
 	// Freezer style fast import the chain.
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.Remove(frdir)
+	frdir := t.TempDir()
+
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -737,18 +734,14 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	blocks, receipts := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, int(height), nil)
 
 	// makeDb creates a db instance for testing.
-	makeDb := func() (ethdb.Database, func()) {
-		dir, err := os.MkdirTemp("", "")
-		if err != nil {
-			t.Fatalf("failed to create temp freezer dir: %v", err)
-		}
-		defer os.Remove(dir)
+	makeDb := func() ethdb.Database {
+		dir := t.TempDir()
 		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
 		gspec.MustCommit(db)
-		return db, func() { os.RemoveAll(dir) }
+		return db
 	}
 	// Configure a subchain to roll back
 	remove := blocks[height/2].NumberU64()
@@ -768,8 +761,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		}
 	}
 	// Import the chain as an archive node and ensure all pointers are updated
-	archiveDb, delfn := makeDb()
-	defer delfn()
+	archiveDb := makeDb()
 
 	archiveCaching := *defaultCacheConfig
 	archiveCaching.TrieDirtyDisabled = true
@@ -785,8 +777,8 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	assert(t, "archive", archive, height/2, height/2, height/2)
 
 	// Import the chain as a non-archive node and ensure all pointers are updated
-	fastDb, delfn := makeDb()
-	defer delfn()
+	fastDb := makeDb()
+
 	fast, _ := NewBlockChain(fastDb, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 	defer fast.Stop()
 
@@ -805,8 +797,8 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	assert(t, "fast", fast, height/2, height/2, 0)
 
 	// Import the chain as a ancient-first node and ensure all pointers are updated
-	ancientDb, delfn := makeDb()
-	defer delfn()
+	ancientDb := makeDb()
+
 	ancient, _ := NewBlockChain(ancientDb, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 	defer ancient.Stop()
 
@@ -824,8 +816,8 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		t.Fatalf("failed to truncate ancient store, want %v, have %v", 1, frozen)
 	}
 	// Import the chain as a light node and ensure all pointers are updated
-	lightDb, delfn := makeDb()
-	defer delfn()
+	lightDb := makeDb()
+
 	light, _ := NewBlockChain(lightDb, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 	if n, err := light.InsertHeaderChain(headers); err != nil {
 		t.Fatalf("failed to insert header %d: %v", n, err)
@@ -1600,11 +1592,7 @@ func TestBlockchainRecovery(t *testing.T) {
 	blocks, receipts := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, int(height), nil)
 
 	// Import the chain as a ancient-first node and ensure all pointers are updated
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.Remove(frdir)
+	frdir := t.TempDir()
 
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
@@ -1672,11 +1660,8 @@ func TestInsertReceiptChainRollback(t *testing.T) {
 	}
 
 	// Set up a BlockChain that uses the ancient store.
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.Remove(frdir)
+	frdir := t.TempDir()
+
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -1876,17 +1861,13 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 		b.OffsetTime(-9) // A higher difficulty
 	})
 	// Import the shared chain and the original canonical one
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.Remove(dir)
+	dir := t.TempDir()
+
 	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
 	new(Genesis).MustCommit(chaindb)
-	defer os.RemoveAll(dir)
 
 	chain, err := NewBlockChain(chaindb, nil, params.TestChainConfig, engine, vm.Config{}, nil, nil, nil)
 	if err != nil {
@@ -2158,11 +2139,8 @@ func TestTransactionIndices(t *testing.T) {
 			}
 		}
 	}
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.Remove(frdir)
+	frdir := t.TempDir()
+
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -2285,11 +2263,8 @@ func TestSkipStaleTxIndicesInFastSync(t *testing.T) {
 		}
 	}
 
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.Remove(frdir)
+	frdir := t.TempDir()
+
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"os"
 	"reflect"
 	"testing"
 
@@ -693,11 +692,7 @@ func checkReceiptsRLP(have, want types.Receipts) error {
 
 func TestAncientStorage(t *testing.T) {
 	// Freezer style fast import the chain.
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.RemoveAll(frdir)
+	frdir := t.TempDir()
 
 	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
@@ -850,11 +845,8 @@ func TestHashesInRange(t *testing.T) {
 // This measures the write speed of the WriteAncientBlocks operation.
 func BenchmarkWriteAncientBlocks(b *testing.B) {
 	// Open freezer database.
-	frdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		b.Fatalf("failed to create temp freezer dir: %v", err)
-	}
-	defer os.RemoveAll(frdir)
+	frdir := b.TempDir()
+
 	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		b.Fatalf("failed to create database with ancient backend")

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"os"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -112,8 +111,7 @@ func TestFreezerModify(t *testing.T) {
 	}
 
 	tables := map[string]bool{"raw": true, "rlp": false}
-	f, dir := newFreezerForTesting(t, tables)
-	defer os.RemoveAll(dir)
+	f, _ := newFreezerForTesting(t, tables)
 	defer f.Close()
 
 	// Commit test data.
@@ -159,7 +157,6 @@ func TestFreezerModifyRollback(t *testing.T) {
 	t.Parallel()
 
 	f, dir := newFreezerForTesting(t, freezerTestTableDef)
-	defer os.RemoveAll(dir)
 
 	theError := errors.New("oops")
 	_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
@@ -190,8 +187,7 @@ func TestFreezerModifyRollback(t *testing.T) {
 func TestFreezerConcurrentModifyRetrieve(t *testing.T) {
 	t.Parallel()
 
-	f, dir := newFreezerForTesting(t, freezerTestTableDef)
-	defer os.RemoveAll(dir)
+	f, _ := newFreezerForTesting(t, freezerTestTableDef)
 	defer f.Close()
 
 	var (
@@ -251,8 +247,7 @@ func TestFreezerConcurrentModifyRetrieve(t *testing.T) {
 
 // This test runs ModifyAncients and TruncateAncients concurrently with each other.
 func TestFreezerConcurrentModifyTruncate(t *testing.T) {
-	f, dir := newFreezerForTesting(t, freezerTestTableDef)
-	defer os.RemoveAll(dir)
+	f, _ := newFreezerForTesting(t, freezerTestTableDef)
 	defer f.Close()
 
 	var item = make([]byte, 256)
@@ -319,10 +314,8 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 func newFreezerForTesting(t *testing.T, tables map[string]bool) (*freezer, string) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "freezer")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
+
 	// note: using low max table size here to ensure the tests actually
 	// switch between multiple files.
 	f, err := newFreezer(dir, "", false, 2049, tables)

--- a/core/state/snapshot/disklayer_test.go
+++ b/core/state/snapshot/disklayer_test.go
@@ -18,7 +18,6 @@ package snapshot
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -519,16 +518,14 @@ func TestDiskSeek(t *testing.T) {
 	// Create some accounts in the disk layer
 	var db ethdb.Database
 
-	if dir, err := os.MkdirTemp("", "disklayer-test"); err != nil {
+	dir := t.TempDir()
+
+	diskdb, err := leveldb.New(dir, 256, 0, "", false)
+	if err != nil {
 		t.Fatal(err)
-	} else {
-		defer os.RemoveAll(dir)
-		diskdb, err := leveldb.New(dir, 256, 0, "", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		db = rawdb.NewDatabase(diskdb)
 	}
+	db = rawdb.NewDatabase(diskdb)
+
 	// Fill even keys [0,2,4...]
 	for i := 0; i < 0xff; i += 2 {
 		acc := common.Hash{byte(i)}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1893,12 +1893,11 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := os.CreateTemp("", "")
+	file, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}
 	journal := file.Name()
-	defer os.Remove(journal)
 
 	// Clean up the temporary file, we only need the path for now
 	file.Close()

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -181,7 +181,7 @@ func TestLoadECDSA(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		f, err := os.CreateTemp("", "loadecdsa_test.*.txt")
+		f, err := os.CreateTemp(t.TempDir(), "loadecdsa_test.*.txt")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -202,13 +202,12 @@ func TestLoadECDSA(t *testing.T) {
 }
 
 func TestSaveECDSA(t *testing.T) {
-	f, err := os.CreateTemp("", "saveecdsa_test.*.txt")
+	f, err := os.CreateTemp(t.TempDir(), "saveecdsa_test.*.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	file := f.Name()
 	f.Close()
-	defer os.Remove(file)
 
 	key, _ := HexToECDSA(testPrivHex)
 	if err := SaveECDSA(file, key); err != nil {

--- a/crypto/signify/signify_test.go
+++ b/crypto/signify/signify_test.go
@@ -33,11 +33,10 @@ var (
 )
 
 func TestSignify(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
 	data := make([]byte, 1024)
@@ -75,11 +74,10 @@ func TestSignify(t *testing.T) {
 }
 
 func TestSignifyTrustedCommentTooManyLines(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
 	data := make([]byte, 1024)
@@ -98,11 +96,10 @@ func TestSignifyTrustedCommentTooManyLines(t *testing.T) {
 }
 
 func TestSignifyTrustedCommentTooManyLinesLF(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
 	data := make([]byte, 1024)
@@ -121,11 +118,10 @@ func TestSignifyTrustedCommentTooManyLinesLF(t *testing.T) {
 }
 
 func TestSignifyTrustedCommentEmpty(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
 	data := make([]byte, 1024)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -19,7 +19,6 @@ package filters
 import (
 	"context"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -42,11 +41,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 }
 
 func BenchmarkFilters(b *testing.B) {
-	dir, err := os.MkdirTemp("", "filtertest")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	var (
 		db, _   = rawdb.NewLevelDBDatabase(dir, 0, 0, "", false)
@@ -95,11 +90,7 @@ func BenchmarkFilters(b *testing.B) {
 }
 
 func TestFilters(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filtertest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var (
 		db, _   = rawdb.NewLevelDBDatabase(dir, 0, 0, "", false)
@@ -259,11 +250,7 @@ func TestFilters(t *testing.T) {
 }
 
 func TestMPSFilters(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filtermpstest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var (
 		db, _   = rawdb.NewLevelDBDatabase(dir, 0, 0, "", false)

--- a/extension/data_handler_test.go
+++ b/extension/data_handler_test.go
@@ -2,7 +2,6 @@ package extension
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -25,13 +24,11 @@ func TestWriteContentsToFileWritesOkay(t *testing.T) {
 		"somekey":                           extensionContracts,
 	}
 
-	datadir, err := os.MkdirTemp("", t.Name())
-	defer os.RemoveAll(datadir)
-	assert.Nil(t, err, "could not create temp directory for test")
+	datadir := t.TempDir()
 
 	dataHandler := NewJsonFileDataHandler(datadir)
 
-	err = dataHandler.Save(psiExtensions)
+	err := dataHandler.Save(psiExtensions)
 	assert.Nil(t, err, "error writing data from file")
 
 	loadedData, err := dataHandler.Load()
@@ -59,13 +56,11 @@ func TestLoadOldContents(t *testing.T) {
 		"somekey":                           extensionContracts,
 	}
 
-	datadir, err := os.MkdirTemp("", t.Name())
-	defer os.RemoveAll(datadir)
-	assert.Nil(t, err, "could not create temp directory for test")
+	datadir := t.TempDir()
 
 	dataHandler := NewJsonFileDataHandler(datadir)
 
-	err = dataHandler.Save(psiExtensions)
+	err := dataHandler.Save(psiExtensions)
 	assert.Nil(t, err, "error writing data from file")
 
 	loadedData, err := dataHandler.Load()

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/coreos/etcd v3.3.27+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/docker/docker v28.0.0+incompatible
 	github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17
 	github.com/eapache/channels v1.1.0
 	github.com/fatih/color v1.17.0
@@ -53,6 +52,7 @@ require (
 	github.com/karalabe/usb v0.0.3-0.20230711191512-61db3e06439c
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20
+	github.com/moby/sys/reexec v0.1.0
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -120,7 +120,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
-	github.com/moby/sys/reexec v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/oklog/run v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,6 @@ github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMa
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/docker v28.0.0+incompatible h1:Olh0KS820sJ7nPsBKChVhk5pzqcwDR15fumfAd/p9hM=
-github.com/docker/docker v28.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17 h1:spJaibPy2sZNwo6Q0HjBVufq7hBUj5jNFOKRoogCBow=
 github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -57,10 +56,8 @@ import (
 )
 
 func TestBuildSchema(t *testing.T) {
-	ddir, err := os.MkdirTemp("", "graphql-buildschema")
-	if err != nil {
-		t.Fatalf("failed to create temporary datadir: %v", err)
-	}
+	ddir := t.TempDir()
+
 	// Copy config
 	conf := node.DefaultConfig
 	conf.DataDir = ddir

--- a/internal/build/util_test.go
+++ b/internal/build/util_test.go
@@ -21,7 +21,7 @@ func TestIgnorePackages_whenIgnoreOnePackage(t *testing.T) {
 	assert := testifyassert.New(t)
 
 	arbitraryPackages := []string{"abc", "xyz/abc"}
-	assert.NoError(os.Setenv("QUORUM_IGNORE_TEST_PACKAGES", "abc"))
+	assert.NoError(os.Setenv("QUORUM_IGNORE_TEST_PACKAGES", "abc")) // nolint:usetesting
 
 	actual := IgnorePackages(arbitraryPackages)
 
@@ -32,7 +32,7 @@ func TestIgnorePackages_whenIgnorePackages(t *testing.T) {
 	assert := testifyassert.New(t)
 
 	arbitraryPackages := []string{"abc", "xyz/abc/opq"}
-	assert.NoError(os.Setenv("QUORUM_IGNORE_TEST_PACKAGES", "abc, xyz/abc"))
+	assert.NoError(os.Setenv("QUORUM_IGNORE_TEST_PACKAGES", "abc, xyz/abc")) // nolint:usetesting
 
 	actual := IgnorePackages(arbitraryPackages)
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -17,7 +17,6 @@
 package flags
 
 import (
-	"os"
 	"os/user"
 	"testing"
 )
@@ -31,7 +30,7 @@ func TestPathExpansion(t *testing.T) {
 		"$DDDXXX/a/b":        "/tmp/a/b",
 		"/a/b/":              "/a/b",
 	}
-	os.Setenv("DDDXXX", "/tmp")
+	t.Setenv("DDDXXX", "/tmp")
 	for test, expected := range tests {
 		got := expandPath(test)
 		if got != expected {

--- a/internal/guide/guide_test.go
+++ b/internal/guide/guide_test.go
@@ -24,7 +24,6 @@ package guide
 
 import (
 	"math/big"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,11 +36,7 @@ import (
 // Tests that the account management snippets work correctly.
 func TestAccountManagement(t *testing.T) {
 	// Create a temporary folder to work with
-	workdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temporary work dir: %v", err)
-	}
-	defer os.RemoveAll(workdir)
+	workdir := t.TempDir()
 
 	// Create an encrypted keystore with standard crypto parameters
 	ks := keystore.NewKeyStore(filepath.Join(workdir, "keystore"), keystore.StandardScryptN, keystore.StandardScryptP)

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -39,23 +39,19 @@ func (no *testNativeObjectBinding) TestMethod(call goja.FunctionCall) goja.Value
 	return no.vm.ToValue(&msg{m})
 }
 
-func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
-	dir, err := os.MkdirTemp("", "jsre-test")
-	if err != nil {
-		t.Fatal("cannot create temporary directory:", err)
-	}
+func newWithTestJS(t *testing.T, testjs string) *JSRE {
+	dir := t.TempDir()
 	if testjs != "" {
 		if err := os.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}
 	jsre := New(dir, os.Stdout)
-	return jsre, dir
+	return jsre
 }
 
 func TestExec(t *testing.T) {
-	jsre, dir := newWithTestJS(t, `msg = "testMsg"`)
-	defer os.RemoveAll(dir)
+	jsre := newWithTestJS(t, `msg = "testMsg"`)
 
 	err := jsre.Exec("test.js")
 	if err != nil {
@@ -77,8 +73,7 @@ func TestExec(t *testing.T) {
 }
 
 func TestNatto(t *testing.T) {
-	jsre, dir := newWithTestJS(t, `setTimeout(function(){msg = "testMsg"}, 1);`)
-	defer os.RemoveAll(dir)
+	jsre := newWithTestJS(t, `setTimeout(function(){msg = "testMsg"}, 1);`)
 
 	err := jsre.Exec("test.js")
 	if err != nil {
@@ -113,8 +108,7 @@ func TestBind(t *testing.T) {
 }
 
 func TestLoadScript(t *testing.T) {
-	jsre, dir := newWithTestJS(t, `msg = "testMsg"`)
-	defer os.RemoveAll(dir)
+	jsre := newWithTestJS(t, `msg = "testMsg"`)
 
 	_, err := jsre.Run(`loadScript("test.js")`)
 	if err != nil {

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -41,11 +41,7 @@ import (
 // ones or automatically generated temporary ones.
 func TestDatadirCreation(t *testing.T) {
 	// Create a temporary data dir and check that it can be used by a node
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create manual data dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	node, err := New(&Config{DataDir: dir})
 	if err != nil {
@@ -67,11 +63,10 @@ func TestDatadirCreation(t *testing.T) {
 		t.Fatalf("freshly created datadir not accessible: %v", err)
 	}
 	// Verify that an impossible datadir fails creation
-	file, err := os.CreateTemp("", "")
+	file, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
-	defer os.Remove(file.Name())
 
 	dir = filepath.Join(file.Name(), "invalid/path")
 	_, err = New(&Config{DataDir: dir})
@@ -118,11 +113,7 @@ func TestIPCPathResolution(t *testing.T) {
 // ephemeral.
 func TestNodeKeyPersistency(t *testing.T) {
 	// Create a temporary folder and make sure no key is present
-	dir, err := os.MkdirTemp("", "node-test")
-	if err != nil {
-		t.Fatalf("failed to create temporary data directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	keyfile := filepath.Join(dir, "unit-test", datadirPrivateKey)
 
@@ -177,10 +168,8 @@ func TestConfig_ResolvePluginBaseDir_whenPluginFeatureIsDisabled(t *testing.T) {
 }
 
 func TestConfig_ResolvePluginBaseDir_whenBaseDirDoesNotExist(t *testing.T) {
-	arbitraryBaseDir := path.Join(os.TempDir(), fmt.Sprintf("foo-%d", time.Now().Unix()))
-	defer func() {
-		_ = os.RemoveAll(arbitraryBaseDir)
-	}()
+	arbitraryBaseDir := path.Join(t.TempDir(), fmt.Sprintf("foo-%d", time.Now().Unix()))
+
 	testObject := &Config{
 		Plugins: &plugin.Settings{
 			BaseDir: plugin.EnvironmentAwaredValue(arbitraryBaseDir),
@@ -193,13 +182,8 @@ func TestConfig_ResolvePluginBaseDir_whenBaseDirDoesNotExist(t *testing.T) {
 }
 
 func TestConfig_ResolvePluginBaseDir_whenBaseDirExists(t *testing.T) {
-	arbitraryBaseDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(arbitraryBaseDir)
-	}()
+	arbitraryBaseDir := t.TempDir()
+
 	testObject := &Config{
 		Plugins: &plugin.Settings{
 			BaseDir: plugin.EnvironmentAwaredValue(arbitraryBaseDir),
@@ -212,13 +196,8 @@ func TestConfig_ResolvePluginBaseDir_whenBaseDirExists(t *testing.T) {
 
 // Quorum
 func TestConfig_IsPermissionEnabled_whenTypical(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpdir)
-	}()
+	tmpdir := t.TempDir()
+
 	if err := os.WriteFile(path.Join(tmpdir, params.PERMISSION_MODEL_CONFIG), []byte("foo"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +222,7 @@ func TestConfig_IsPermissionEnabled_whenPermissionedFlagIsFalse(t *testing.T) {
 func TestConfig_IsPermissionEnabled_whenPermissionConfigIsNotAvailable(t *testing.T) {
 	testObject := &Config{
 		EnableNodePermission: true,
-		DataDir:              os.TempDir(),
+		DataDir:              t.TempDir(),
 	}
 
 	assert.False(t, testObject.IsPermissionEnabled())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -87,11 +86,7 @@ func TestNodeStartMultipleTimes(t *testing.T) {
 // Tests that if the data dir is already in use, an appropriate error is returned.
 func TestNodeUsedDataDir(t *testing.T) {
 	// Create a temporary folder to use as the data directory
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary data directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create a new node based on the data directory
 	original, err := New(&Config{DataDir: dir})

--- a/p2p/enode/nodedb_test.go
+++ b/p2p/enode/nodedb_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -299,11 +298,7 @@ func testSeedQuery() error {
 }
 
 func TestDBPersistency(t *testing.T) {
-	root, err := os.MkdirTemp("", "nodedb-")
-	if err != nil {
-		t.Fatalf("failed to create temporary data folder: %v", err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	var (
 		testKey = []byte("somekey")

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -489,11 +489,8 @@ func TestServerSetupConn_whenNotInRaftCluster(t *testing.T) {
 }
 
 func TestServerSetupConn_whenNotPermissioned(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
+
 	if err := os.WriteFile(path.Join(tmpDir, params.PERMISSIONED_CONFIG), []byte("[]"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -517,7 +514,7 @@ func TestServerSetupConn_whenNotPermissioned(t *testing.T) {
 	}
 	defer srv.Stop()
 	p1, _ := net.Pipe()
-	err = srv.SetupConn(p1, inboundConn, clientNode)
+	err := srv.SetupConn(p1, inboundConn, clientNode)
 
 	assert.IsType(t, &peerError{}, err)
 	perr := err.(*peerError)

--- a/permission/core/permissions_test.go
+++ b/permission/core/permissions_test.go
@@ -23,8 +23,7 @@ func TestIsNodePermissioned(t *testing.T) {
 		datadir     string
 		direction   string
 	}
-	d, _ := os.MkdirTemp("", "qdata")
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	writeNodeToFile(d, params.PERMISSIONED_CONFIG, node1)
 	writeNodeToFile(d, params.PERMISSIONED_CONFIG, node3)
 	writeNodeToFile(d, params.DISALLOWED_CONFIG, node3)
@@ -69,8 +68,7 @@ func Test_isNodeBlackListed(t *testing.T) {
 		dataDir  string
 	}
 
-	d, _ := os.MkdirTemp("", "qdata")
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	writeNodeToFile(d, params.DISALLOWED_CONFIG, node1)
 	n1, _ := enode.ParseV4(node1)
 	n2, _ := enode.ParseV4(node2)

--- a/permission/permission_test.go
+++ b/permission/permission_test.go
@@ -758,8 +758,7 @@ func TestPermissionCtrl_whenUpdateFile(t *testing.T) {
 	err := testObject.populateInitPermissions(orgCacheSize, roleCacheSize, nodeCacheSize, accountCacheSize)
 	assert.NoError(t, err)
 
-	d, _ := os.MkdirTemp("", "qdata")
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	testObject.dataDir = d
 	ptype.UpdatePermissionedNodes(testObject.node, d, arbitraryNode1, ptype.NodeAdd, true)
@@ -802,8 +801,7 @@ func TestPermissionCtrl_whenUpdateFile(t *testing.T) {
 }
 
 func TestParsePermissionConfig(t *testing.T) {
-	d, _ := os.MkdirTemp("", "qdata")
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	_, err := ptype.ParsePermissionConfig(d)
 	assert.True(t, err != nil, "expected file not there error")

--- a/plugin/central_test.go
+++ b/plugin/central_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path"
 	"runtime"
 	"testing"
@@ -94,13 +93,8 @@ func TestCentralClient_PluginSignature(t *testing.T) {
 }
 
 func TestCentralClient_PluginDistribution(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	arbitraryDef := &PluginDefinition{
 		Name:    "arbitrary-plugin",
 		Version: "1.0.0",
@@ -116,7 +110,7 @@ func TestCentralClient_PluginDistribution(t *testing.T) {
 
 	testObject := NewPluginCentralClient(arbitraryConfig)
 
-	err = testObject.PluginDistribution(arbitraryDef, path.Join(tmpDir, "download.zip"))
+	err := testObject.PluginDistribution(arbitraryDef, path.Join(tmpDir, "download.zip"))
 
 	assert.NoError(t, err)
 }

--- a/plugin/downloader_test.go
+++ b/plugin/downloader_test.go
@@ -11,13 +11,8 @@ import (
 )
 
 func TestDownloader_Download_whenPluginIsAvailableLocally(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "p-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	arbitraryPluginDistPath := path.Join(tmpDir, fmt.Sprintf("arbitrary-plugin-1.0.0-%s-%s.zip", runtime.GOOS, runtime.GOARCH))
 	if err := os.WriteFile(arbitraryPluginDistPath, []byte{}, 0644); err != nil {
 		t.Fatal(err)

--- a/plugin/local_verifier_test.go
+++ b/plugin/local_verifier_test.go
@@ -9,13 +9,8 @@ import (
 )
 
 func TestLocalVerifier_VerifySignature(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	arbitraryPluginDefinition := &PluginDefinition{
 		Name:    "arbitrary-plugin",
 		Version: "1.0.0",

--- a/plugin/settings_test.go
+++ b/plugin/settings_test.go
@@ -26,13 +26,11 @@ func TestReadMultiFormatConfig_whenConfigEmbeddedAsArray(t *testing.T) {
 }
 
 func TestReadMultiFormatConfig_whenConfigEmbeddedAsFile(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "q-")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "q-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = os.Remove(tmpFile.Name())
-	}()
+
 	av1 := "arbitrary value1"
 	_, err = tmpFile.WriteString(av1)
 	if err != nil {
@@ -61,9 +59,8 @@ func TestReadMultiFormatConfig_whenFromEnvVariable(t *testing.T) {
 	assert := testifyassert.New(t)
 
 	arbitraryString := "arbitrary config string"
-	if err := os.Setenv("KEY1", arbitraryString); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("KEY1", arbitraryString)
+
 	cfg, err := ReadMultiFormatConfig("env://KEY1")
 
 	assert.NoError(err)
@@ -71,22 +68,19 @@ func TestReadMultiFormatConfig_whenFromEnvVariable(t *testing.T) {
 }
 
 func TestReadMultiFormatConfig_whenFromEnvFile(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "q-")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "q-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = os.Remove(tmpFile.Name())
-	}()
+
 	av1 := "arbitrary value1"
 	_, err = tmpFile.WriteString(av1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log("wrote tmp file: " + tmpFile.Name())
-	if err := os.Setenv("KEY1", tmpFile.Name()); err != nil {
-		t.Fatal(err)
-	}
+
+	t.Setenv("KEY1", tmpFile.Name())
 
 	assert := testifyassert.New(t)
 	cfg, err := ReadMultiFormatConfig("env://KEY1?type=file")
@@ -98,9 +92,7 @@ func TestReadMultiFormatConfig_whenFromEnvFile(t *testing.T) {
 func TestEnvironmentAwaredValue_UnmarshalJSON_whenValueFromEnvVariable(t *testing.T) {
 	assert := testifyassert.New(t)
 
-	if err := os.Setenv("KEY1", "foo"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("KEY1", "foo")
 
 	var value struct {
 		Vinstance EnvironmentAwaredValue
@@ -140,9 +132,7 @@ Vpointer = "bar"`), &value))
 func TestEnvironmentAwaredValue_UnmarshalTOML_whenValueFromEnvVariable(t *testing.T) {
 	assert := testifyassert.New(t)
 
-	if err := os.Setenv("KEY1", "foo"); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("KEY1", "foo")
 
 	var value struct {
 		Vinstance EnvironmentAwaredValue

--- a/plugin/utils_test.go
+++ b/plugin/utils_test.go
@@ -46,13 +46,8 @@ func TestIsCleanEntryPoint(t *testing.T) {
 }
 
 func TestResolveFilePath_whenTypical(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	f, err := os.CreateTemp(tmpDir, "f-")
 	if err != nil {
 		t.Fatal(err)
@@ -88,20 +83,14 @@ func TestVerify_whenInvalid(t *testing.T) {
 }
 
 func TestUnpackPlugin_whenTypical(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	tmpZipFile, err := createArbitraryZip(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	workspace, meta, err := unpackPlugin(tmpZipFile)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/verifier_test.go
+++ b/plugin/verifier_test.go
@@ -9,13 +9,8 @@ import (
 )
 
 func TestNewVerifier_whenResolvingDefaultPublicKeyLocation(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "q-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
+
 	if err := os.WriteFile(path.Join(tmpDir, DefaultPublicKeyFile), []byte("foo"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/private/private_test.go
+++ b/private/private_test.go
@@ -43,7 +43,7 @@ func TestFromEnvironmentOrNil_whenUsingUnixSocketWithConstellation(t *testing.T)
 			t.Errorf("panic received: %s", r)
 		}
 	}()
-	os.Setenv("ARBITRARY_CONFIG_ENV", socketFile)
+	t.Setenv("ARBITRARY_CONFIG_ENV", socketFile)
 	cfg, err := FromEnvironmentOrNil("ARBITRARY_CONFIG_ENV")
 	assert.NoError(t, err, "unexpected error")
 
@@ -68,7 +68,7 @@ func TestFromEnvironmentOrNil_whenUsingUnixSocketWithTessera(t *testing.T) {
 			t.Errorf("panic received: %s", r)
 		}
 	}()
-	os.Setenv("ARBITRARY_CONFIG_ENV", socketFile)
+	t.Setenv("ARBITRARY_CONFIG_ENV", socketFile)
 	cfg, err := FromEnvironmentOrNil("ARBITRARY_CONFIG_ENV")
 	assert.NoError(t, err, "unexpected error")
 

--- a/raft/backend_test.go
+++ b/raft/backend_test.go
@@ -1,7 +1,6 @@
 package raft
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -24,13 +23,7 @@ func Test_New_RegistersEthServicePendingLogsFeed(t *testing.T) {
 		t.Fatalf("failed to create eth service, err = %v", err)
 	}
 
-	tmpWorkingDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpWorkingDir)
-	}()
+	tmpWorkingDir := t.TempDir()
 
 	raftService, err := New(stack, &params.ChainConfig{}, 0, 0, false, time.Second, ethService, nil, tmpWorkingDir, false)
 	if err != nil {

--- a/raft/handler_test.go
+++ b/raft/handler_test.go
@@ -29,13 +29,9 @@ import (
 func TestProtocolManager_whenAppliedIndexOutOfSync(t *testing.T) {
 	logger := log.New()
 	logger.SetHandler(log.StreamHandler(os.Stdout, log.TerminalFormat(false)))
-	tmpWorkingDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpWorkingDir)
-	}()
+
+	tmpWorkingDir := t.TempDir()
+
 	count := 3
 	ports := make([]uint16, count)
 	nodeKeys := make([]*ecdsa.PrivateKey, count)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -870,7 +870,7 @@ func TestClient_whenProvidingPSIViaEnvVar(t *testing.T) {
 		f := func(transport string) {
 			expectedPSI := "PS1"
 			t.Setenv(EnvVarPrivateStateIdentifier, expectedPSI)
-			defer os.Unsetenv(EnvVarPrivateStateIdentifier)
+
 			srvHandler, srvHttp := startHTTPTestServer(transport)
 			defer func() {
 				srvHandler.Stop()

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -869,7 +869,7 @@ func TestClient_whenProvidingPSIViaEnvVar(t *testing.T) {
 	for _, transport := range []string{"http", "ws"} {
 		f := func(transport string) {
 			expectedPSI := "PS1"
-			assert.NoError(t, os.Setenv(EnvVarPrivateStateIdentifier, expectedPSI))
+			t.Setenv(EnvVarPrivateStateIdentifier, expectedPSI)
 			defer os.Unsetenv(EnvVarPrivateStateIdentifier)
 			srvHandler, srvHttp := startHTTPTestServer(transport)
 			defer func() {

--- a/rpc/security_test.go
+++ b/rpc/security_test.go
@@ -256,7 +256,7 @@ func TestResolvePSIProvider_whenTypicalEndpoints(t *testing.T) {
 }
 
 func TestResolvePSIProvider_whenEnvVariableTakesPrecedence(t *testing.T) {
-	_ = os.Setenv(EnvVarPrivateStateIdentifier, "ENV_PS1")
+	t.Setenv(EnvVarPrivateStateIdentifier, "ENV_PS1")
 	defer func() { _ = os.Unsetenv(EnvVarPrivateStateIdentifier) }()
 
 	endpoint := "http://aritraryhost?PSI=PS1"

--- a/rpc/security_test.go
+++ b/rpc/security_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -257,7 +256,6 @@ func TestResolvePSIProvider_whenTypicalEndpoints(t *testing.T) {
 
 func TestResolvePSIProvider_whenEnvVariableTakesPrecedence(t *testing.T) {
 	t.Setenv(EnvVarPrivateStateIdentifier, "ENV_PS1")
-	defer func() { _ = os.Unsetenv(EnvVarPrivateStateIdentifier) }()
 
 	endpoint := "http://aritraryhost?PSI=PS1"
 	actualCtx := resolvePSIProvider(context.Background(), endpoint)

--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -106,11 +106,8 @@ func (ui *headlessUi) ShowInfo(message string) {
 }
 
 func tmpDirName(t *testing.T) string {
-	d, err := os.MkdirTemp("", "eth-keystore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	d, err = filepath.EvalSymlinks(d)
+	d := t.TempDir()
+	d, err := filepath.EvalSymlinks(d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/fourbyte/fourbyte_test.go
+++ b/signer/fourbyte/fourbyte_test.go
@@ -18,7 +18,6 @@ package fourbyte
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -57,10 +56,7 @@ func TestEmbeddedDatabase(t *testing.T) {
 // Tests that custom 4byte datasets can be handled too.
 func TestCustomDatabase(t *testing.T) {
 	// Create a new custom 4byte database with no embedded component
-	tmpdir, err := os.MkdirTemp("", "signer-4byte-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpdir := t.TempDir()
 	filename := fmt.Sprintf("%s/4byte_custom.json", tmpdir)
 
 	db, err := NewWithFile(filename)

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -61,10 +61,7 @@ func TestFileStorage(t *testing.T) {
 			CipherText: common.Hex2Bytes("2df87baf86b5073ef1f03e3cc738de75b511400f5465bb0ddeacf47ae4dc267d"),
 		},
 	}
-	d, err := os.MkdirTemp("", "eth-encrypted-storage-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 	stored := &AESEncryptedStorage{
 		filename: fmt.Sprintf("%v/vault.json", d),
 		key:      []byte("AES256Key-32Characters1234567890"),
@@ -94,10 +91,7 @@ func TestFileStorage(t *testing.T) {
 func TestEnd2End(t *testing.T) {
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(3), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 
-	d, err := os.MkdirTemp("", "eth-encrypted-storage-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 
 	s1 := &AESEncryptedStorage{
 		filename: fmt.Sprintf("%v/vault.json", d),
@@ -119,10 +113,7 @@ func TestSwappedKeys(t *testing.T) {
 	// K1:V1, K2:V2 can be swapped into K1:V2, K2:V1
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(3), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 
-	d, err := os.MkdirTemp("", "eth-encrypted-storage-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 
 	s1 := &AESEncryptedStorage{
 		filename: fmt.Sprintf("%v/vault.json", d),


### PR DESCRIPTION
close #122 

This pull request refactors the test codebase to use Go's `t.TempDir()` for managing temporary directories instead of manually creating and cleaning up directories with `os.MkdirTemp` and `os.RemoveAll`. This change simplifies test setup and teardown, reduces boilerplate, and makes the tests more robust and idiomatic. Additionally, a new linter (`usetesting`) is added to the configuration to encourage best practices in using the `testing` package.

Key changes include:

### Testing improvements

* Replaced manual temporary directory management (`os.MkdirTemp` and `os.RemoveAll`) with `t.TempDir()` across all test files. 

### Linter configuration

* Added the `usetesting` linter to `.golangci.yml` to enforce and encourage idiomatic usage of the Go `testing` package, such as preferring `t.TempDir()` over manual directory management.
