### PR TITLE
Add 'mirror' to the enabled linters in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,8 +10,8 @@ linters:
     - gocheckcompilerdirectives
     - govet
     - ineffassign
-    - misspell
     - mirror
+    - misspell
     - reassign
     - staticcheck
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - mirror
     - reassign
     - staticcheck
     - unconvert

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -182,7 +182,7 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 		}
 		// Parse library references.
 		for pattern, name := range libs {
-			matched, err := regexp.Match("__\\$"+pattern+"\\$__", []byte(contracts[types[i]].InputBin))
+			matched, err := regexp.MatchString("__\\$"+pattern+"\\$__", contracts[types[i]].InputBin)
 			if err != nil {
 				log.Error("Could not search for pattern", "pattern", pattern, "contract", contracts[types[i]], "err", err)
 			}

--- a/cmd/geth/accountcmd_plugin_test.go
+++ b/cmd/geth/accountcmd_plugin_test.go
@@ -180,7 +180,7 @@ func TestImportPluginAccount_ErrIfCLIFlagsNotSet(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("creating tmp file", "path", tmpfile.Name())
 
-	_, err = tmpfile.Write([]byte("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b"))
+	_, err = tmpfile.WriteString("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b")
 	require.NoError(t, err)
 	err = tmpfile.Close()
 	require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestImportPluginAccount_ErrIfInvalidNewAccountConfig(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("creating tmp file", "path", tmpfile.Name())
 
-	_, err = tmpfile.Write([]byte("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b"))
+	_, err = tmpfile.WriteString("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b")
 	require.NoError(t, err)
 	err = tmpfile.Close()
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestImportPluginAccount_ErrIfUnsupportedPluginInConfig(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("creating tmp file", "path", tmpfile.Name())
 
-	_, err = tmpfile.Write([]byte("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b"))
+	_, err = tmpfile.WriteString("1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b")
 	require.NoError(t, err)
 	err = tmpfile.Close()
 	require.NoError(t, err)


### PR DESCRIPTION
This pull request introduces minor improvements to code quality and test clarity, as well as a small update to linting configuration. The main changes include switching to more idiomatic Go functions in tests, improving a regular expression usage, and enabling an additional linter.

Code quality and correctness:

* Updated `accounts/abi/bind/bind.go` to use `regexp.MatchString` instead of `regexp.Match`, simplifying the regular expression call and making the code more idiomatic.

Testing improvements:

* Updated three test functions in `cmd/geth/accountcmd_plugin_test.go` to use `WriteString` instead of `Write([]byte(...))` when writing test data to temporary files, improving code readability and intent. [[1]](diffhunk://#diff-c0f8d849ac7db3406eca3050e38425645b8dc546baacce4f04ba1794703f0779L183-R183) [[2]](diffhunk://#diff-c0f8d849ac7db3406eca3050e38425645b8dc546baacce4f04ba1794703f0779L221-R221) [[3]](diffhunk://#diff-c0f8d849ac7db3406eca3050e38425645b8dc546baacce4f04ba1794703f0779L267-R267)

Linting configuration:

* Added the `mirror` linter to the `.golangci.yml` configuration to enhance static analysis coverage.