### PR TITLE
Remove unnecessary closure variable reassignments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   default: none
   enable:
     - bidichk
+    - copyloopvar
     - durationcheck
     - gocheckcompilerdirectives
     - govet

--- a/accounts/abi/event_test.go
+++ b/accounts/abi/event_test.go
@@ -327,7 +327,6 @@ func TestEventTupleUnpack(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert := assert.New(t)
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := unpackTestEventData(tc.dest, tc.data, tc.jsonLog, assert)
 			if tc.error == "" {

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -362,7 +362,6 @@ func TestMethodMultiReturn(t *testing.T) {
 		"Can not unpack into a slice with wrong types",
 	}}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			err := abi.UnpackIntoInterface(tc.dest, "multi", data)

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -114,7 +114,6 @@ func TestAccountImport(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			importAccountWithExpect(t, test.key, test.output)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -605,7 +605,6 @@ func (d *Downloader) spawnSync(fetchers []func() error) error {
 	errc := make(chan error, len(fetchers))
 	d.cancelWg.Add(len(fetchers))
 	for _, fn := range fetchers {
-		fn := fn
 		go func() { defer d.cancelWg.Done(); errc <- fn() }()
 	}
 	// Wait for the first error, then terminate the others.

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -459,7 +459,7 @@ func (f *BlockFetcher) loop() {
 				log.Trace("Fetching scheduled headers", "peer", peer, "list", hashes)
 
 				// Create a closure of the fetch and schedule in on a new thread
-				fetchHeader, hashes := f.fetching[hashes[0]].fetchHeader, hashes
+				fetchHeader := f.fetching[hashes[0]].fetchHeader
 				go func() {
 					if f.fetchingHook != nil {
 						f.fetchingHook(hashes)

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -404,8 +404,6 @@ func testTransactionPropagation(t *testing.T, protocol uint) {
 	}
 	// Interconnect all the sink handlers with the source handler
 	for i, sink := range sinks {
-		sink := sink // Closure for gorotuine below
-
 		sourcePipe, sinkPipe := p2p.MsgPipe()
 		defer sourcePipe.Close()
 		defer sinkPipe.Close()
@@ -496,8 +494,6 @@ func testQuorumTransactionPropagation(t *testing.T, protocol uint) {
 	wgExpectPeerMessages.Add(numberOfPeers)
 	// Interconnect all the sink handlers with the source handler
 	for i, sink := range sinks {
-		sink := sink // Closure for gorotuine below
-
 		sourcePipe, sinkPipe := p2p.MsgPipe()
 		defer sourcePipe.Close()
 		defer sinkPipe.Close()
@@ -686,8 +682,6 @@ func testBroadcastBlock(t *testing.T, peers, bcasts int) {
 		td      = source.chain.GetTd(genesis.Hash(), genesis.NumberU64())
 	)
 	for i, sink := range sinks {
-		sink := sink // Closure for gorotuine below
-
 		sourcePipe, sinkPipe := p2p.MsgPipe()
 		defer sourcePipe.Close()
 		defer sinkPipe.Close()
@@ -721,7 +715,6 @@ func testBroadcastBlock(t *testing.T, peers, bcasts int) {
 	// Iterate through all the sinks and ensure the correct number got the block
 	done := make(chan struct{}, peers)
 	for _, ch := range blockChs {
-		ch := ch
 		go func() {
 			<-ch
 			done <- struct{}{}

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -104,8 +104,6 @@ type TxPool interface {
 func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2p.Protocol {
 	protocols := make([]p2p.Protocol, len(ProtocolVersions))
 	for i, version := range ProtocolVersions {
-		version := version // Closure
-
 		protocols[i] = p2p.Protocol{
 			Name:    ProtocolName,
 			Version: version,

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -92,8 +92,6 @@ func MakeProtocols(backend Backend, dnsdisc enode.Iterator) []p2p.Protocol {
 
 	protocols := make([]p2p.Protocol, len(ProtocolVersions))
 	for i, version := range ProtocolVersions {
-		version := version // Closure
-
 		protocols[i] = p2p.Protocol{
 			Name:    ProtocolName,
 			Version: version,

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -212,7 +212,6 @@ func TestCallTracer(t *testing.T) {
 		if !strings.HasPrefix(file.Name(), "call_tracer_") {
 			continue
 		}
-		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(strings.TrimPrefix(file.Name(), "call_tracer_"), ".json")), func(t *testing.T) {
 			t.Parallel()
 

--- a/les/api_test.go
+++ b/les/api_test.go
@@ -152,7 +152,6 @@ func testCapacityAPI(t *testing.T, clientCount int) {
 		// Send light request like crazy.
 		for i, c := range clientRpcClients {
 			wg.Add(1)
-			i, c := i, c
 			go func() {
 				defer wg.Done()
 

--- a/les/commons.go
+++ b/les/commons.go
@@ -75,7 +75,6 @@ type NodeInfo struct {
 func (c *lesCommons) makeProtocols(versions []uint, runPeer func(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) error, peerInfo func(id enode.ID) interface{}, dialCandidates enode.Iterator) []p2p.Protocol {
 	protos := make([]p2p.Protocol, len(versions))
 	for i, version := range versions {
-		version := version
 		protos[i] = p2p.Protocol{
 			Name:     "les",
 			Version:  version,

--- a/node/api_test.go
+++ b/node/api_test.go
@@ -244,7 +244,6 @@ func TestStartRPC(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -527,7 +527,6 @@ func TestNodeRPCPrefix(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		name := fmt.Sprintf("http=%s ws=%s", test.httpPrefix, test.wsPrefix)
 		t.Run(name, func(t *testing.T) {
 			cfg := &Config{

--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -357,7 +357,6 @@ func TestTestVectorsV5(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			net := newHandshakeTest()
 			defer net.close()

--- a/p2p/nodestate/nodestate.go
+++ b/p2p/nodestate/nodestate.go
@@ -749,7 +749,6 @@ func (ns *NodeStateMachine) Operation(fn func()) error {
 // offlineCallbacks calls state update callbacks at startup or shutdown
 func (ns *NodeStateMachine) offlineCallbacks(start bool) {
 	for _, cb := range ns.offlineCallbackList {
-		cb := cb
 		callback := func() {
 			for _, sub := range ns.stateSubs {
 				offState := offlineState & sub.mask

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -399,7 +399,6 @@ outer:
 func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error) {
 	p.wg.Add(len(p.running))
 	for _, proto := range p.running {
-		proto := proto
 		proto.closed = p.closed
 		proto.wstart = writeStart
 		proto.werr = writeErr

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -572,7 +572,6 @@ func TestClientHTTP(t *testing.T) {
 	)
 	defer client.Close()
 	for i := range results {
-		i := i
 		go func() {
 			errc <- client.Call(&results[i], "test_echo", wantResult.String, wantResult.Int, wantResult.Args)
 		}()

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -62,7 +62,6 @@ func TestState(t *testing.T) {
 	} {
 		st.walk(t, dir, func(t *testing.T, name string, test *StateTest) {
 			for _, subtest := range test.Subtests() {
-				subtest := subtest
 				key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 				name := name + "/" + key
 


### PR DESCRIPTION
This pull request primarily removes unnecessary variable reassignments in range loops throughout the codebase, which were previously used to avoid closure capture issues in goroutines and subtests. These changes simplify the code and rely on Go's improved handling of range variable capture since Go 1.22. 

Additionally, a new linter is enabled to help catch potential issues with loop variables in the future.

### Linter configuration

* Enabled the `copyloopvar` linter in `.golangci.yml` to help detect incorrect usage of loop variables in closures.

### Code cleanup and simplification

* Removed redundant reassignments of range variables (e.g., `var := var`) in test files and goroutine closures.