### PR TITLE
Add Dependabot config for Go, CI, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      # Quorum relies on a forked etcd replacement pinned in go.mod.
+      - dependency-name: "github.com/coreos/etcd"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request introduces a `.github/dependabot.yml` configuration file to automate dependency updates for Go modules, GitHub Actions, and Docker files.

Dependabot configuration and automation:

* Added `.github/dependabot.yml` to enable automated updates for Go modules, GitHub Actions, and Docker dependencies, each with custom schedules, labels, commit message prefixes, and grouping rules.
* Configured Dependabot to ignore updates for `github.com/coreos/etcd` in Go modules due to reliance on a forked replacement.