### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,18 +32,3 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
-      - "docker"
-    commit-message:
-      prefix: "chore(docker)"
-      include: "scope"
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"


### PR DESCRIPTION
This pull request makes a small change to the `.github/dependabot.yml` configuration. It removes the configuration for Docker dependency updates, so Dependabot will no longer check for or update Docker dependencies.