### PR TITLE
Check snapshot staleness before diff reads

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -292,6 +292,11 @@ func (dl *diffLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
+	// Check staleness before reaching further.
+	if dl.Stale() {
+		dl.lock.RUnlock()
+		return nil, ErrSnapshotStale
+	}
 	hit := dl.diffed.Contains(accountBloomHasher(hash))
 	if !hit {
 		hit = dl.diffed.Contains(destructBloomHasher(hash))
@@ -358,6 +363,11 @@ func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
+	// Check staleness before reaching further.
+	if dl.Stale() {
+		dl.lock.RUnlock()
+		return nil, ErrSnapshotStale
+	}
 	hit := dl.diffed.Contains(storageBloomHasher{accountHash, storageHash})
 	if !hit {
 		hit = dl.diffed.Contains(destructBloomHasher(accountHash))


### PR DESCRIPTION
Add early staleness checks to diffLayer read paths (AccountRLP and Storage).

Ref: https://github.com/ethereum/go-ethereum/issues/27254

* Added a staleness check at the beginning of the `AccountRLP` method to return `ErrSnapshotStale` if the diff layer is stale, preventing further processing on outdated data.
* Added a staleness check at the beginning of the `Storage` method to return `ErrSnapshotStale` if the diff layer is stale, ensuring operations are only performed on valid data.
